### PR TITLE
Added image generation support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,13 @@
     {
       "js": ["libs/pdf.min.js", "content-script.js"],
       "matches": ["<all_urls>"]
+    },
+    {
+      "js": ["shell/csp_disable.js"],
+      "matches": ["https://*.bing.com/*"],
+      "run_at": "document_idle",
+      "all_frames": true,
+      "world": "MAIN"
     }
   ],
   "commands": {

--- a/shell/csp_disable.js
+++ b/shell/csp_disable.js
@@ -1,0 +1,7 @@
+(function clearCSP() {
+  const csp = document.querySelectorAll(".underside-shell-frame");
+  csp.forEach((el) => {
+    console.log(el);
+    el.removeAttribute("csp");
+  });
+})();


### PR DESCRIPTION
Added image support by disabling CSP on the loaded page using content_script. It's a quiet straightforward way, but it's working.

![image](https://github.com/chathub-dev/bing-chat-sidebar-for-chrome/assets/44484815/2a37a253-c50a-459c-bdde-ed319c83660a)
